### PR TITLE
fix: edit config error

### DIFF
--- a/config.py
+++ b/config.py
@@ -10,7 +10,7 @@ def getConfig():
 def updateConfig():
     mw.addonManager.writeConfig(__name__,userOption)
 
-def newConf():
+def newConf(newUserOption):
     global userOption
-    userOption = None
+    userOption = newUserOption
 mw.addonManager.setConfigUpdatedAction(__name__,newConf)


### PR DESCRIPTION
Hi,
    I found that there is a changing config bug.  We need to define the newUserOption param, so it can change config without error.

anki source is here: https://github.com/dae/anki/blob/master/aqt/addons.py#L763